### PR TITLE
Fix typo in detection pipelines

### DIFF
--- a/hailo_apps_infra/detection_pipeline.py
+++ b/hailo_apps_infra/detection_pipeline.py
@@ -43,7 +43,7 @@ class GStreamerDetectionApp(GStreamerApp):
         parser.add_argument(
             "--labels-json",
             default=None,
-            help="Path to costume labels JSON file",
+            help="Path to custom labels JSON file",
         )
         # Call the parent class constructor
         super().__init__(parser, user_data)

--- a/hailo_apps_infra/detection_pipeline_simple.py
+++ b/hailo_apps_infra/detection_pipeline_simple.py
@@ -43,7 +43,7 @@ class GStreamerDetectionApp(GStreamerApp):
         parser.add_argument(
             "--labels-json",
             default=None,
-            help="Path to costume labels JSON file",
+            help="Path to custom labels JSON file",
         )
 
         # Call the parent class constructor


### PR DESCRIPTION
## Summary
- fix typos in the help strings for detection pipelines

## Testing
- `./run_tests.sh` *(fails: Could not download dependencies and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6719418832c857d01028f696448